### PR TITLE
ci: always run publish regardless of changed paths

### DIFF
--- a/.github/workflows/pr-auth-validate.yaml
+++ b/.github/workflows/pr-auth-validate.yaml
@@ -70,7 +70,6 @@ jobs:
           echo "CHANGED_HANDLES=$CHANGED_HANDLES" >> $GITHUB_ENV
 
       - name: Authorize
-        if: ${{ env.CHANGED_HANDLES != '' }}
         shell: bash
         env:
           AUTHOR_LOGIN: ${{ github.event.pull_request.user.login }}
@@ -78,7 +77,6 @@ jobs:
         run: pnpm authz
 
       - name: Validate changes
-        if: ${{ env.CHANGED_HANDLES != '' }}
         shell: bash
         env:
           LICENSE_DETECTION_SCRIPT: |
@@ -86,7 +84,6 @@ jobs:
         run: pnpm validate-changes
 
       - name: Display publish plan
-        if: ${{ env.CHANGED_HANDLES != '' }}
         shell: bash
         run: |
-          test -s "$PUBLISH_PLAN_PATH" && cat "$PUBLISH_PLAN_PATH" || echo "No publish plan."
+          [ -s "$PUBLISH_PLAN_PATH" ] && cat "$PUBLISH_PLAN_PATH" || echo "No publish plan."

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - "publishers/*.yaml"
-      - "widgets/*.yaml"
 
 env:
   GITHUB_TOKEN: ${{ github.token }}
@@ -80,7 +77,6 @@ jobs:
           echo "CHANGED_HANDLES=$CHANGED_HANDLES" >> $GITHUB_ENV
 
       - name: Validate changes
-        if: ${{ env.CHANGED_HANDLES != '' }}
         id: validate-changes
         shell: bash
         env:


### PR DESCRIPTION
We are now comparing the registry checkpoint against the HEAD, so even if the current push to main (merged PR) does not change something, there could be previous things to catch up with. In any case if really `CHANGED_HANDLES` gives nothing, then `HAS_PUBLISH_PLAN` will be false and we won't publish anyways.