### PR TITLE
ci: fix registry update authentication

### DIFF
--- a/.github/workflows/pr-auth-validate.yaml
+++ b/.github/workflows/pr-auth-validate.yaml
@@ -7,7 +7,7 @@ on:
       - "widgets/*.yaml"
 
 env:
-  GITHUB_TOKEN: ${{ github.token }}
+  GH_TOKEN: ${{ github.token }}
   BASE_SHA: ${{ github.event.pull_request.base.sha }}
   HEAD_SHA: ${{ github.event.pull_request.head.sha }}
   PUBLISH_PLAN_PATH: "publish-plan.ndjson"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,7 +6,7 @@ on:
       - main
 
 env:
-  GITHUB_TOKEN: ${{ github.token }}
+  GH_TOKEN: ${{ github.token }}
   HEAD_SHA: ${{ github.sha }}
   PUBLISH_PLAN_PATH: "publish-plan.ndjson"
 
@@ -129,7 +129,7 @@ jobs:
       - name: Login to GHCR
         shell: bash
         run: |
-          echo "$GITHUB_TOKEN" | oras login ghcr.io -u "${{ github.actor }}" --password-stdin
+          echo "$GH_TOKEN" | oras login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Download publish plan
         uses: actions/download-artifact@v6
@@ -156,6 +156,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          gh auth setup-git
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           cd "$REGISTRY_DIR"

--- a/scripts/lib/github.ts
+++ b/scripts/lib/github.ts
@@ -2,12 +2,12 @@ import { Octokit } from "octokit";
 
 const GITHUB_API_VERSION = "2022-11-28";
 
-const GITHUB_TOKEN = process.env["GITHUB_TOKEN"];
-if (GITHUB_TOKEN === undefined) {
-  console.warn("Missing environment variable: GITHUB_TOKEN");
+const GH_TOKEN = process.env["GH_TOKEN"];
+if (GH_TOKEN === undefined) {
+  console.warn("Missing environment variable: GH_TOKEN");
 }
 
-const octokit = new Octokit({ auth: GITHUB_TOKEN });
+const octokit = new Octokit({ auth: GH_TOKEN });
 
 export async function isOrgMember(params: {
   orgId: number;


### PR DESCRIPTION
Failed action: https://github.com/deskulpt-apps/widgets/actions/runs/19852129541/job/56881243184. This PR first changes `GITHUB_TOKEN` all to `GH_TOKEN` (to be consistent with what `gh` CLI looks at), then use `gh auth setup-git` to try to solve the `fatal: could not read Username for 'https://github.com/': No such device or address` problem when pushing the registry worktree to remote.